### PR TITLE
Fix terminal_width to work properly on windows

### DIFF
--- a/lib/powerbar.rb
+++ b/lib/powerbar.rb
@@ -310,7 +310,8 @@ class PowerBar
 
   def terminal_width
     rows, cols = IO.console.winsize
-    cols - 1
+    cols -= 1 if Gem.win_platform?
+    cols
   end
 
   private

--- a/lib/powerbar.rb
+++ b/lib/powerbar.rb
@@ -308,14 +308,20 @@ class PowerBar
   end
 
   def terminal_width
+    require 'io/console'
+    rows, cols = IO.console.winsize
+    cols - 1
+  rescue LoadError #io/console not in ruby < 1.9.3
     if /solaris/ =~ RUBY_PLATFORM && (`stty` =~ /\brows = (\d+).*\bcolumns = (\d+)/)
       w, r = [$2, $1]
+    elsif Gem.win_platform?
+      w, r = `stty size 2>NUL`.split.reverse
     else
       w, r = `stty size 2>/dev/null`.split.reverse
     end
     w = `tput cols` unless w
     w = w.to_i if w
-    w
+    w - 1
   end
 
   private

--- a/lib/powerbar.rb
+++ b/lib/powerbar.rb
@@ -22,6 +22,7 @@
 
 require 'powerbar/version'
 require 'hashie/mash'
+require 'io/console'
 
 #
 # This is PowerBar - The last progressbar-library you'll ever need.
@@ -308,20 +309,8 @@ class PowerBar
   end
 
   def terminal_width
-    require 'io/console'
     rows, cols = IO.console.winsize
     cols - 1
-  rescue LoadError #io/console not in ruby < 1.9.3
-    if /solaris/ =~ RUBY_PLATFORM && (`stty` =~ /\brows = (\d+).*\bcolumns = (\d+)/)
-      w, r = [$2, $1]
-    elsif Gem.win_platform?
-      w, r = `stty size 2>NUL`.split.reverse
-    else
-      w, r = `stty size 2>/dev/null`.split.reverse
-    end
-    w = `tput cols` unless w
-    w = w.to_i if w
-    w - 1
   end
 
   private


### PR DESCRIPTION
- Windows shell uses NUL instead of /dev/null to discard output. Before, this method would print "The system cannot find the file specified," which defeats the purpose of the redirection
- Running `stty size` on Windows takes a non-trivial amount of time, so for Ruby >= 1.9.3, IO.console is used instead on all platforms
- As with #1, both CMD and powershell are also horribly broken, and subtracting 1 from the columns is required to keep the bar from wrapping